### PR TITLE
Update 0x08-V3-Cryptography_Verificiation_Requirements.md

### DIFF
--- a/Document/0x08-V3-Cryptography_Verificiation_Requirements.md
+++ b/Document/0x08-V3-Cryptography_Verificiation_Requirements.md
@@ -17,13 +17,14 @@ Cryptography is an essential ingredient when it comes to protecting data stored 
 | **3.1** | Verify that that the application does not rely on symmetric cryptography with hardcoded keys as a sole method of encryption.| ✓ | ✓ | ✓ | ✓ |
 | **3.2** | Verify that the cryptographic primitives used adhere to industry standards. Algorithms that are widely considered weak should not be used.| ✓ | ✓ | ✓ | ✓ |
 | **3.3** | Verify that cryptographic modules operate using parameters that are considered secure (e.g. mode, key length). | ✓ | ✓| ✓ | ✓ |
-| **3.4** | If proprietary cryptographic algorithms are used, verify the security of these algorithms. Note that proven standard algorithms are recommended over self-written ones. | ✓ | ✓ | ✓ | ✓ |
-| **3.5** | Verify that the application doesn't re-use the same cryptographical key for multiple purposes. | ✓ | ✓ | ✓ | ✓ |
-| **3.6** | Verify that all random numbers, random file names, random GUIDs, and random strings are generated using a secure random number generator. |   | ✓ | ✓ | ✓ |
-| **3.7** | Verify that all keys and passwords are changeable, and are generated or replaced at installation time. |   | ✓ | ✓ | ✓ |
-| **3.8** | Verify that random numbers are created with proper entropy during the application lifecycle. |   |   | ✓ | ✓ |
-| **3.9** | Verify that cryptographic controls do not keep any reference to a key in memory (e.g. bouncy castle's working key). |   |   | ✓ | ✓ |
-| **3.10** | Verify that consumers of cryptographic services do not have direct access to key material. Isolate cryptographic processes, including master secrets through the use of strong software protections or a hardware key vault (HSM). |   |   |   | ✓ |
+| **3.4** | Verify that the application doesn't re-use the same cryptographical key for multiple purposes. | ✓ | ✓ | ✓ | ✓ |
+| **3.5** | Verify that all random numbers, random file names, random GUIDs, and random strings are generated using a secure random number generator. |   | ✓ | ✓ | ✓ |
+| **3.6** | Verify that all keys and passwords are changeable, and are generated or replaced at installation time. |   | ✓ | ✓ | ✓ |
+| **3.7** | Verify that random numbers are created with proper entropy during the application lifecycle. |   |   | ✓ | ✓ |
+| **3.8** | Verify that cryptographic controls do not keep any reference to (or a copy of) a (working)key in memory. |   |   | ✓ | ✓ |
+| **3.9** | Verify that consumers of cryptographic services do not have direct access to key material if the keying material is locally generated. Isolate cryptographic processes, including master secrets through the use of strong software protections or a hardware key vault (HSM).  |   |   |   | ✓ |
+| **3.10** | Verify that keying materials are refreshed per session and stored at the server for non-repudiation instead of on the device. |   |   |   | ✓ |
+| **3.11** | Verify that keying materials have been applied as such that forward secrecy is provided.|   |   | ✓ | ✓ |
 
 ## References
 


### PR DESCRIPTION
- Removed note regarding proprietary: we should NOT recommend on using it. Anti tampering techniques (obfuscating used techniques), should be part of V9 (anti reverse-engineering techniques)
- Removed notion of bouncey castle working key: we need to make sure that it's technology independent. Let's make sure that we cover this in the testing guide
- Regarding 3.9: I changed it as such to make sure that we have 3.10 & 3.11 as we cannot trust the secure storage on the device: even the TEE on android for instance, can be hacked. See the vulnerabilities patched in the may 2016 patch.