### PR TITLE
Update 0x06 with remote enforcements

### DIFF
--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -22,6 +22,8 @@ The high level requirements are as follows:
 | **1.7** | Verify that all application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ | ✓ | ✓ |
 | **1.8** | Verify that all components that are not part of the application but that the application relies on to operate, are defined in terms of the functions, and/or security functions, they provide. |   | ✓ | ✓ | ✓ |
 | **1.9** | If the app uses cryptography, verify that there is an explicit policy for how cryptographic keys are managed (e.g. generated, distributed, revoked, and expired), and verify that the key lifecycle is properly enforced. |   | ✓ | ✓ | ✓ |
+| **1.10** | Verify that security controls are not only enforced on an app, but on the respective endpoints as well. |   | ✓ | ✓ | ✓ |
+| **1.11** | Verify that application-blacklisting (- or whitelisting) is in place based on the application verison & identifiers.  |   |  | ✓ | ✓ |
 
 ## References
 


### PR DESCRIPTION
Additions based on the dicussion at https://github.com/OWASP/owasp-masvs/issues/40. This should fix this issue.
Please note that we might have to make 1.10 more specific again: authentication, encryption, data-storage, non-repudiation, etc.. should all be part of this.