### PR TITLE
Update 0x06 V1: aded not sharing authentication information

### DIFF
--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -22,6 +22,7 @@ The high level requirements are as follows:
 | **1.7** | Verify that all application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ | ✓ | ✓ |
 | **1.8** | Verify that all components that are not part of the application but that the application relies on to operate, are defined in terms of the functions, and/or security functions, they provide. |   | ✓ | ✓ | ✓ |
 | **1.9** | If the app uses cryptography, verify that there is an explicit policy for how cryptographic keys are managed (e.g. generated, distributed, revoked, and expired), and verify that the key lifecycle is properly enforced. |   | ✓ | ✓ | ✓ |
+| **1.10** | Verify that authentication information for other channels is not reused int he mobile implementation to prevent cross-platform account compromise. |   |  |  | ✓ |
 
 ## References
 


### PR DESCRIPTION
As discussed in https://github.com/OWASP/owasp-masvs/issues/33 : separation of authentication information to not compromise both web- and mobile platforms as well