### PR TITLE
V1.6 improved wording by replacing implemented' with 'integrated'.

### DIFF
--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -18,7 +18,7 @@ The high level requirements are as follows:
 | **1.3** | Security controls are never enforced only on the client-side, but on the respective remote endpoints. | ✓ | ✓ |
 | **1.4** | A high-level architecture for the mobile application and all connected remote services has been defined and security has been addressed in that architecture. | ✓ | ✓ |
 | **1.5** | A threat model for the mobile app and the associated remote services has been produced that identifies potential threats and countermeasures. |   | ✓ |
-| **1.6** | All third party components have been assessed (associated risks) before being used or implemented. A process is in place to ensure that each time a security update for a third party component is published, the change is inspected and the risk evaluated. |   | ✓ |
+| **1.6** | All third party components have been assessed (associated risks) before being used or integrated. A process is in place to ensure that each time a security update for a third party component is published, the change is inspected and the risk evaluated. |   | ✓ |
 | **1.7** | All security controls (including libraries that call external security services) have a centralized implementation. |   | ✓ |
 | **1.8** | All application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ |
 | **1.9** | All components that are not part of the application but that the application relies on to operate, are defined in terms of the functions, and/or security functions, they provide. |   | ✓ |

--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -21,7 +21,7 @@ The high level requirements are as follows:
 | **1.6** | All third party components have been assessed (associated risks) before being used or integrated. A process is in place to ensure that each time a security update for a third party component is published, the change is inspected and the risk evaluated. |   | ✓ |
 | **1.7** | All security controls (including libraries that call external security services) have a centralized implementation. |   | ✓ |
 | **1.8** | All application components are defined in terms of the business functions and/or security functions they provide. |   | ✓ |
-| **1.9** | All components that are not part of the application but that the application relies on to operate, are defined in terms of the functions, and/or security functions, they provide. |   | ✓ |
+| **1.9** | All components that are not part of the application but that the application relies on to operate, are defined regarding the business functions, and/or security functions, they provide. |   | ✓ |
 | **1.10** | There is an explicit policy for how cryptographic keys (if any) are managed, and the lifecycle of cryptographic keys is enforced. Ideally, follow a key management standard such as NIST SP 800-57. |   | ✓ |
 | **1.11** | A process is in place to monitor first and third party app stores for copies of the app and for fake apps using a similar brand or name. |   | ✓ |
 | **1.12** | Application blacklisting (or whitelisting) is in place based on the application version & identifiers. |   | ✓ |


### PR DESCRIPTION
I believe that better wording would be to use integrated instead of implemented. 
In my view a Mobile App can:
- uses  a thirty party service e.g. an external database (no changes here)
- integrates a thirty party component e.g. a library 
BUT cannot 
- implements a thirty party component e.g. a library
