### PR TITLE
Updates reference links for MSTG

### DIFF
--- a/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -39,8 +39,9 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 (...TODO... link this to v1.0 instead of master once tagged).
 
-- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01a_OMTG-DATAST_Android.md
-- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x02a_OMTG-DATAST_iOS.md
+- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md
+- iOS -
+https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md
 
 For more information, see also:
 

--- a/Document/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document/0x08-V3-Cryptography_Verification_Requirements.md
@@ -25,8 +25,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 (...TODO... link this to v1.0 instead of master once tagged).
 
-- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01b_OMTG-CRYPTO_Android.md
-- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x02b_OMTG-CRYPTO_iOS.md
+- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05e-Testing-Cryptography.md
+- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06e-Testing-Cryptography.md
 
 For more information, see also:
 

--- a/Document/0x09-V4-Authentication_and_Session_Management Requirements.md
+++ b/Document/0x09-V4-Authentication_and_Session_Management Requirements.md
@@ -25,8 +25,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 (...TODO... link this to v1.0 instead of master once tagged).
 
-- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01c_OMTG-AUTH_Android.md
-- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x02c_OMTG-AUTH_iOS.md
+- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05f-Testing-Authentication.md
+- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06f-Testing-Authentication-and-Session-Management.md
 
 For more information, see also:
 

--- a/Document/0x10-V5-Network_communication_requirements.md
+++ b/Document/0x10-V5-Network_communication_requirements.md
@@ -20,8 +20,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 (...TODO... link this to v1.0 instead of master once tagged).
 
-- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01d_OMTG-NET_Android.md
-- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x02d_OMTG-NET_iOS.md
+- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md
+- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06g-Testing-Network-Communication.md
 
 For more information, see also:
 

--- a/Document/0x11-V6-Interaction_with_the_environment.md
+++ b/Document/0x11-V6-Interaction_with_the_environment.md
@@ -25,8 +25,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 (...TODO... link this to v1.0 instead of master once tagged).
 
-- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01e_OMTG-ENV_Android.md
-- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x02e_OMTG-ENV_iOS.md
+- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md
+- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md
 
 For more information, see also:
 

--- a/Document/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -24,8 +24,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 (...TODO... link this to v1.0 instead of master once tagged).
 
-- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01f_OMTG-CODE_Android.md
-- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01f_OMTG-CODE_iOS.md
+- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05i-Testing-Code-Quality-and-Build-Settings.md
+- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
 
 For more information, see also:
 

--- a/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -48,7 +48,7 @@ The following considerations apply:
 
 | # | Description | R |
 | --- | --- | --- | --- |
-| **8.13** | The app uses multiple functionally independent means of emulator detection that, in context of the overall protection scheme, force adversaries to invest significant manual effort to run the app in an emulator (supersedes requirement 8.5). | ✓ 
+| **8.13** | The app uses multiple functionally independent means of emulator detection that, in context of the overall protection scheme, force adversaries to invest significant manual effort to run the app in an emulator (supersedes requirement 8.5). | ✓
 | **8.14** | If the architecture requires sensitive information be stored on the device, the app only runs on operating system versions and devices that offer hardware-backed key storage. Alternatively, the information is protected using obfuscation. Considering current published research, the obfuscation type and parameters are sufficient to cause significant manual effort to reverse engineers seeking to comprehend or extract the sensitive data. | ✓ |
 | **8.15** | If the architecture requires sensitive computations be performed on the client-side, these computations are isolated from the operating system by using a hardware-based SE or TEE. Alternatively, the information is protected using obfuscation. Considering current published research, the obfuscation type and parameters are sufficient to cause significant manual effort to reverse engineers seeking to comprehend the sensitive portions of the code and/or data.  | ✓ |
 
@@ -59,8 +59,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 (...TODO... link this to v1.0 instead of master once tagged).
 
-- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x01g_OMTG-RARE_Android.md
-- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/Testcases/0x02g_OMTG-RARE_iOS.md
+- Android - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md
+- iOS - https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
 
 For more information, see also:
 


### PR DESCRIPTION
The reference links for the OWASP Mobile Security Testing Guide are updated with its current directory structure.