### PR TITLE
Added 5.6 for security providers/connectivity providers

### DIFF
--- a/Document/0x10-V5-Network_communication_requirements.md
+++ b/Document/0x10-V5-Network_communication_requirements.md
@@ -13,6 +13,7 @@ The purpose of the controls listed in this section is to ensure the confidential
 | **5.3** | The app verifies the X.509 certificate of the remote endpoint when the secure channel is established. Only certificates signed by a valid CA are accepted. | ✓ | ✓ |
 | **5.4** | The app either uses its own certificate store, or pins the endpoint certificate or public key, and subsequently does not establish connections with endpoints that offer a different certificate or key, even if signed by a trusted CA. |   | ✓ |
 | **5.5** | The app doesn't rely on a single insecure communication channel (email or SMS) for critical operations, such as enrollments and account recovery. |  | ✓ |
+| **5.6** | the app only depends on up to date connectivity- and security libraries. |  | ✓ |
 
 ## References
 


### PR DESCRIPTION
We need to explain to the developers that they should patch the security provider and pack a patched version of a security library in iOS (e.g. open-ssl or something else) in case of having a high risk application