### PR TITLE
Fix whitespace on 8.11

### DIFF
--- a/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -37,7 +37,7 @@ The following considerations apply:
 
 | # | Description | R |
 | --- | --- | --- |
-| **8.11**| The app implements a 'device binding' functionality using a device fingerprint derived from multiple properties unique to the device. | ✓ |
+| **8.11** | The app implements a 'device binding' functionality using a device fingerprint derived from multiple properties unique to the device. | ✓ |
 
 ### Impede Comprehension
 


### PR DESCRIPTION
Put a space between the asterisk and the pipe, otherwise the export script
won't detect it as a requirement line.