### PR TITLE
minor: focus v6.8 on *de*serialization

### DIFF
--- a/Document/0x11-V6-Interaction_with_the_environment.md
+++ b/Document/0x11-V6-Interaction_with_the_environment.md
@@ -15,7 +15,7 @@ The controls in this group ensure that the app uses platform APIs and standard c
 | **6.5** | JavaScript is disabled in WebViews unless explicitly required. | ✓ | ✓ |
 | **6.6** | WebViews are configured to allow only the minimum set of protocol handlers required (ideally, only https is supported). Potentially dangerous handlers, such as file, tel and app-id, are disabled. | ✓ | ✓ |
 | **6.7** | If native methods of the app are exposed to a WebView, verify that the WebView only renders JavaScript contained within the app package. | ✓ | ✓ |
-| **6.8** | Object serialization, if any, is implemented using safe serialization APIs. | ✓ | ✓ |
+| **6.8** | Object deserialization, if any, is implemented using safe serialization APIs. | ✓ | ✓ |
 
 ## References
 


### PR DESCRIPTION
Just a minor suggestion: it seems to me that it is object *de*serialization that is potentially dangerous to the application. I suggest focusing ***v6.8*** on this half of object marshaling.