### PR TITLE
Ignore File fields when generating CSV with export.py

### DIFF
--- a/masvs.py
+++ b/masvs.py
@@ -75,7 +75,7 @@ class MASVS:
         ''' Returns CSV '''
         si = StringIO()
 
-        writer = csv.DictWriter(si, ['id', 'text'])
+        writer = csv.DictWriter(si, ['id', 'text'], extrasaction='ignore')
         writer.writeheader()
         writer.writerows(self.requirements)
 


### PR DESCRIPTION
The `export.py` script was broken for generating CSVs, because the `File` field wasn't accounted for by the `DictWriter`. This change tells the writer to ignore extra fields.