### PR TITLE
#138: Added proper sponsoring text

### DIFF
--- a/Document/0x02-Frontispiece.md
+++ b/Document/0x02-Frontispiece.md
@@ -22,3 +22,11 @@ Copyright © 2018 The OWASP Foundation. This document is released under the Crea
 | Sven Schleier & Jeroen Willemsen| Bernhard Mueller | Stephen Corbiaux, Sven Schleier, Anant Shrivastava, Abdessamad Temmar, Alexander Antukh, Roberto Martelloni, Stefaan Seys, Prabhant Singh, Francesco Stillavato, Abhinav Sejpal |
 
 This document started as a fork of the OWASP Application Security Verification Standard written by Jim Manico.
+
+## Sponsors
+
+While both the MASVS and the MSTG are created and maintained by the community on a voluntary basis, sometimes a little bit of outside help is required. We therefore thank our sponsors for providing the funds to be able to hire technical editors. Note that their sponsorship does not influence the content of the MASVS or MSTG in any way. The sponsorship packages are described on the [Owasp Projeect Wiki](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide#tab=Sponsorship_Packages "Owasp Mobile Security Testing Guide Sponsorship Packages").
+
+#### Honourable Benefactor
+
+[![NowSecure](Images/Sponsors/NowSecure_logo.png)](https://www.nowsecure.com/ "NowSecure")


### PR DESCRIPTION
Added SecureNow as a sponsor! We are thrilled to have them to pay for the technical editors.