### PR TITLE
Fix link to OWASP logo

### DIFF
--- a/Document-de/0x00-Header.md
+++ b/Document-de/0x00-Header.md
@@ -1,5 +1,5 @@
 
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Mobile Application Security Verification Standard
 

--- a/Document-de/0x02-Frontispiece.md
+++ b/Document-de/0x02-Frontispiece.md
@@ -1,4 +1,4 @@
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Mobile Application Security Verification Standard
 

--- a/Document-es/0x00-Header.md
+++ b/Document-es/0x00-Header.md
@@ -1,4 +1,4 @@
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Estándar de Verificación de Seguridad en Aplicaciones Móviles
 

--- a/Document-es/0x02-Frontispiece.md
+++ b/Document-es/0x02-Frontispiece.md
@@ -1,4 +1,4 @@
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Estándar de Verificación de Seguridad en Aplicaciones Móviles
 

--- a/Document-fr/0x00-Header.md
+++ b/Document-fr/0x00-Header.md
@@ -1,5 +1,4 @@
-
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Standard de Validation de la Sécurité des Applications Mobiles (Mobile Application Security Verification Standard - MASVS)
 

--- a/Document-fr/0x02-Frontispiece.md
+++ b/Document-fr/0x02-Frontispiece.md
@@ -1,5 +1,4 @@
-
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Standard de Validation de la Sécurité des Applications Mobiles (Mobile Application Security Verification Standard - MASVS)
 

--- a/Document-ja/0x00-Header.md
+++ b/Document-ja/0x00-Header.md
@@ -1,4 +1,3 @@
-
 ![OWASP LOGO](images/OWASP_logo.png)
 
 # モバイルアプリケーションセキュリティ検証標準 - リリース 1.1

--- a/Document-ja/0x02-Frontispiece.md
+++ b/Document-ja/0x02-Frontispiece.md
@@ -1,4 +1,4 @@
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 
 # Mobile Application Security Verification Standard

--- a/Document-zhtw/0x00-Header.md
+++ b/Document-zhtw/0x00-Header.md
@@ -1,5 +1,4 @@
-
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Mobile Application Security Verification Standard
 

--- a/Document-zhtw/0x02-Frontispiece.md
+++ b/Document-zhtw/0x02-Frontispiece.md
@@ -1,4 +1,4 @@
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Mobile Application Security Verification Standard
 

--- a/Document/0x00-Header.md
+++ b/Document/0x00-Header.md
@@ -1,5 +1,5 @@
 
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Mobile Application Security Verification Standard
 

--- a/Document/0x02-Frontispiece.md
+++ b/Document/0x02-Frontispiece.md
@@ -1,4 +1,4 @@
-![OWASP LOGO](Images/OWASP_logo.png)
+![OWASP LOGO](images/OWASP_logo.png)
 
 # Mobile Application Security Verification Standard
 


### PR DESCRIPTION
The folder is called images with lower case i. This is wrongly referenced on two pages.