### PR TITLE
Fix typos

### DIFF
--- a/Document-fr/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-fr/0x08-V3-Cryptography_Verification_Requirements.md
@@ -2,7 +2,7 @@
 
 ## Objectif de Contrôle
 
-La cryptographie est un ingredient essentiel pour la protection des données stockées sur un appareil mobile. C'est aussi une catégorie pour laquelle les choses peuvent très mal se passer, en particulier quand les conventions standards ne sont pas suivies. Le but des contrôles de ce chapitre est de garantir que les applications à valider implémentent la cryptographie en suivant les bonnes pratiques de l'industrie, notamment :
+La cryptographie est un ingrédient essentiel pour la protection des données stockées sur un appareil mobile. C'est aussi une catégorie pour laquelle les choses peuvent très mal se passer, en particulier quand les conventions standards ne sont pas suivies. Le but des contrôles de ce chapitre est de garantir que les applications à valider implémentent la cryptographie en suivant les bonnes pratiques de l'industrie, notamment :
 
 - L'utilisation de librairies cryptographiques éprouvées ;
 - Le choix et la configuration pertinents des primitives cryptographiques ;
@@ -12,12 +12,12 @@ La cryptographie est un ingredient essentiel pour la protection des données sto
 
 | # | Description | L1 | L2 |
 | --- | --- | --- | --- |
-| **3.1** | L'application n'utilise pas la cryptographie symétrique avec des clés codées en dur comme seule méthode de cryptage.| ✓ | ✓ |
+| **3.1** | L'application n'utilise pas la cryptographie symétrique avec des clés codées en dur comme seule méthode de chiffrement.| ✓ | ✓ |
 | **3.2** | L'application utilise des implémentations de primitives cryptographiques éprouvées. | ✓ | ✓ |
 | **3.3** | L'application utilise des primitives cryptographiques appropriées au cas d'utilisation, configurées en adéquation avec les bonnes pratiques de l'industrie. | ✓ | ✓|
 | **3.4** | L'application n'utilise pas de protocole ou d'algorithme de cryptographie considéré par la communauté comme déprécié pour des raisons de sécurité. | ✓ | ✓|
 | **3.5** | L'application ne ré-utilise pas la même clé de cryptographie à des fins différentes. | ✓ | ✓ |
-| **3.6** | Toute valeur aléatoire est générée par un générateur de nombre aléatoire offrant un bon niveau de sécurité. | ✓ | ✓ |
+| **3.6** | Toute valeur aléatoire est générée par un générateur de nombres aléatoires offrant un bon niveau de sécurité. | ✓ | ✓ |
 
 ## Références
 


### PR DESCRIPTION
"ingredients" -> "ingrédients", "cryptage" -> "chiffrement" (inaccurate translation), "nombre aléatoire" -> "nombres aléatoires"