### PR TITLE
Fix tables on gitbook

### DIFF
--- a/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -14,7 +14,6 @@ Sensitive data in the context of the MASVS pertains to both user credentials and
 - Highly sensitive data that would lead to reputational harm and/or financial costs if compromised: Contractual information, information covered by non-disclosure agreements, management information;
 - Any data that must be protected by law or for compliance reasons.
 
-<div style="page-break-after: always;"></div>
 
 ## Security Verification Requirements
 

--- a/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -14,6 +14,9 @@ Sensitive data in the context of the MASVS pertains to both user credentials and
 - Highly sensitive data that would lead to reputational harm and/or financial costs if compromised: Contractual information, information covered by non-disclosure agreements, management information;
 - Any data that must be protected by law or for compliance reasons.
 
+<div style="page-break-after: always;">
+\pagebreak
+</div>
 
 ## Security Verification Requirements
 

--- a/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -18,7 +18,6 @@ The following considerations apply:
 
 3. The effectiveness of the protection should always be verified by a human expert with experience in testing the particular types of anti-tampering and obfuscation used (see also the "reverse engineering" and "assessing software protections" chapters in the Mobile Security Testing Guide).
 
-<div style="page-break-after: always;"></div>
 
 ### Impede Dynamic Analysis and Tampering
 

--- a/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -46,7 +46,9 @@ The following considerations apply:
 | **8.11** | MSTG‑RESILIENCE‑11 |All executable files and libraries belonging to the app are either encrypted on the file level and/or important code and data segments inside the executables are encrypted or packed. Trivial static analysis does not reveal important code or data. | ✓ |
 | **8.12** | MSTG‑RESILIENCE‑12 | If the goal of obfuscation is to protect sensitive computations, an obfuscation scheme is used that is both appropriate for the particular task and robust against manual and automated de-obfuscation methods, considering currently published research. The effectiveness of the obfuscation scheme must be verified through manual testing. Note that hardware-based isolation features are preferred over obfuscation whenever possible. | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;">
+\pagebreak
+</div>
 
 ## References
 


### PR DESCRIPTION
Two pages have broken tables on GitHub, most likely due to the pagebreak html. I've removed them in this branch.

https://mobile-security.gitbook.io/masvs/security-requirements/0x07-v2-data_storage_and_privacy_requirements
https://mobile-security.gitbook.io/masvs/security-requirements/0x15-v8-resiliency_against_reverse_engineering_requirements