### PR TITLE
Fix pages on gitbook

### DIFF
--- a/Document-de/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-de/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -25,7 +25,8 @@ Die Anforderungen für MASVS-L1 und MASVS-L2 sind nachfolgend aufgelistet.
 | **1.9** | MSTG‑ARCH‑9 | Es gibt einen Mechanismus in der mobilen App um App-Aktualisierungen zu erzwingen. |   | ✓ |
 | **1.10** | MSTG‑ARCH‑10 | Security wird in allen Teilen des Softwareentwicklungszyklus berücksichtigt. |   | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Referenzen
 

--- a/Document-de/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-de/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -13,7 +13,8 @@ Sensible Daten im Kontext des MASVS sind jegliche Nutzer-Anmeldedaten sowie alle
 - Hoch sensible Daten deren Kompromittierung zu hohem Reputationsverlust oder finanziellen Aufwänden führen würde: Vertragsinformationen, Informationen die durch Verschwiegenheitserklärungen geschützt sind, Management Informationen;
 - Alle Daten die durch gesetzliche Bestimmungen oder aufgrund regulatorischer Vorgaben (Compliance) zu schützen sind.
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Anforderungen
 
@@ -34,7 +35,8 @@ Ein Großteil von Datenpannen kann bereits durch Einhaltung einfacher Regeln ver
 | **2.11** | MSTG‑STORAGE‑11 | Die App erzwingt ein Minimum an Geräteschutz-Richtlinien wie das Definieren eines Gerätepassworts. |  | ✓ |
 | **2.12** | MSTG‑STORAGE‑12 | Die App klärt den Nutzer über die Art und Weise der verarbeiteten personenbezogenen Daten auf und gibt dem Nutzer Security-Best-Practice-Empfehlungen zum Umgang mit der App. |  | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Referenzen
 

--- a/Document-de/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-de/0x08-V3-Cryptography_Verification_Requirements.md
@@ -19,7 +19,8 @@ Kryptographie ist eine wesentlicher Eckpfeiler zum Schutz von Daten, die auf mob
 | **3.5** | MSTG‑CRYPTO‑5 | Die App verwendet einen kryptographischen Schlüssel für genau einen Zweck und nicht für mehrere Zwecke. | ✓ | ✓ |
 | **3.6** | MSTG‑CRYPTO‑6 | Alle Zufallswerte werden über einen ausreichend sicheren kryptographischen Zufallszahlengenerator erzeugt. | ✓ | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Referenzen
 

--- a/Document-de/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-de/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -20,6 +20,9 @@ Ein integraler Teil der Architektur einer mobilen App ist der Login eines Nutzer
 | **4.10** | MSTG‑AUTH‑10 | Sensible Transaktionen erfordern eine zusätzliche Authentifizierung (durch einen weiteren Authentifizierungsfaktor). |   | ✓ |
 | **4.11** | MSTG‑AUTH‑11 | Die App informiert den Nutzer über alle Anmelde-Vorgänge am Nutzerkonto. Nutzer können eine Liste aller mit dem Konto verbundenen Geräte sehen und ausgewählte Geräte blockieren. |  | ✓ |
 
+<div style="page-break-after: always;" >
+</div>
+
 ## Referenzen
 
 Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die Anforderungen aus dieser Kategorie zu überprüfen.

--- a/Document-de/0x10-V5-Network_communication_requirements.md
+++ b/Document-de/0x10-V5-Network_communication_requirements.md
@@ -15,7 +15,8 @@ Der Zweck dieser Kategorie ist es die Vertraulichkeit und Integrität übertrage
 | **5.5** | MSTG‑NETWORK‑5 | Die App nutzt keine unsicheren Kommunikationskanäle wie Email oder SMS für kritische Operationen wie Konten-Registrierung oder Konten-Reaktivierung. |  | ✓ |
 | **5.6** | MSTG‑NETWORK‑6 | Die App nutzt aktuelle Bibliotheken zum Aufbau von sicheren Kommunikationsverbindungen. |  | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Referenzen
 

--- a/Document-de/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-de/0x11-V6-Interaction_with_the_environment.md
@@ -17,7 +17,8 @@ Die Anforderungen aus dieser Kategorie sollen sicherstellen, dass Plattform-Komp
 | **6.7** | MSTG‑PLATFORM‑7 | Wenn eine WebView über Javascript Zugriff auf native Methoden einer App bekommt, ist sichergestellt, dass die WebView nur vorgegebenes Javascript aus der App rendert und kein Javascript aus externen Quellen.  | ✓ | ✓ |
 | **6.8** | MSTG‑PLATFORM‑8 | Objektserialisierung wird, falls vorhanden, über eine sichere Serialisierungs-API implementiert. | ✓ | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Referenzen
 

--- a/Document-de/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-de/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -18,7 +18,8 @@ Das Ziel dieser Kategorie ist, sicherzustellen, dass bei der App-Entwicklung Bas
 | **7.8** | MSTG‑CODE‑8 | Das Speichermanagement (Allokation und Freigabe von Speicher) erfolgt in unmanaged code auf sichere Weise. | ✓ | ✓ |
 | **7.9** | MSTG‑CODE‑9 | Angebotene Sicherheitsfunktionen der Entwicklungsumgebung wie Byte-Code Minimierung, Stack-Protection, PIE-Support und automatisches Reference-Counting sind aktiviert. | ✓ | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Referenzen
 

--- a/Document-de/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-de/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -18,7 +18,8 @@ Folgende Eckpunkte gelten:
 
 3. Die Effektivität der Schutzmaßnahmen sollte immer von einem Experten mit ausgewiesener Erfahrung im Bereich Anti-Code-Manipulation und Code-Obfuskierung überprüft werden (siehe auch Kapitel "reverse engineering" and "assessing software protections" im Mobile Security Testing Guide).
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ### Dynamische Analyse und Manipulation verhindern
 
@@ -48,7 +49,10 @@ Folgende Eckpunkte gelten:
 | --- | --- | --- | -- |
 | **8.11** | MSTG‑RESILIENCE‑11 | Alle ausführbaren Dateien und Bibliotheken der App sind entweder auf Dateiebene verschlüsselt und/oder wichtige Code- und Datenabsegmente in ausführbaren Dateien sind verschlüsselt oder durch Packing obfuskiert. Triviale statische Analyse offenbart keinen wichtigen Code oder Daten. | ✓ |
 | **8.12** | MSTG‑RESILIENCE‑12 | Wenn das Ziel der Obfuskierung der Schutz sensibler Logik wie Algorithmen oder Berechnungen ist, so wird ein angemessener Obfuskierungsmechanismus, dem Stand der Technik entsprechend, genutzt der resilient gegen manuelle und automatisierte De-Obfuskierungsangriffe ist. Die Wirksamkeit der Obfuskierungsmethode muss durch manuelle Tests überprüft werden. Es ist zu beachten, dass hardware-basierte Isolations-Mechanismen softwarebasierter Obfuskierung vorzuziehen sind. | ✓ |
-<div style="page-break-after: always;"></div>
+
+<div style="page-break-after: always;" >
+</div>
+
 ## Referenzen
 
 Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die Anforderungen aus dieser Kategorie zu überprüfen.

--- a/Document-fr/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-fr/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -14,7 +14,8 @@ Dans le contexte du MASVS, les données sensibles ont trait aux deux aspects que
 - Information hautement sensible pouvant amener à une perte de réputation et/ou un coût financier si elle était divulguée : information contractuelle, information sous le coup de clauses de non-divulgation, information de gestion ;
 - Toute information devant être protégée légalement ou pour des raisons de conformité.
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Exigences pour la Validation de la Sécurité
 

--- a/Document-fr/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-fr/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -18,7 +18,7 @@ Le but de ce contrôle est d'assurer que les pratiques de codage de base concern
 | **7.8** | MSTG‑CODE‑8 | Dans le code non-géré, la mémoire est allouée, libérée et utilisée de façon sécurisée.  | ✓ | ✓ |
 | **7.9** | MSTG‑CODE‑9 | Les fonctionnalités de sécurité intégrées dans les outils de la chaîne de génération, par exemple ceux pour la minification de byte-code, pour la protection de la pile, pour le support PIE ou le comptage de références automatiques, sont activées. | ✓ | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" /></div>
 
 ## Références
 

--- a/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -14,7 +14,8 @@ Sensitive data in the context of the MASVS pertains to both user credentials and
 - Highly sensitive data that would lead to reputational harm and/or financial costs if compromised: Contractual information, information covered by non-disclosure agreements, management information;
 - Any data that must be protected by law or for compliance reasons.
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## Security Verification Requirements
 

--- a/Document/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -18,7 +18,8 @@ The goal of this control is to ensure that basic security coding practices are f
 | **7.8** | MSTG‑CODE‑8 | In unmanaged code, memory is allocated, freed and used securely.  | ✓ | ✓ |
 | **7.9** | MSTG‑CODE‑9 | Free security features offered by the toolchain, such as byte-code minification, stack protection, PIE support and automatic reference counting, are activated. | ✓ | ✓ |
 
-<div style="page-break-after: always;"></div>
+<div style="page-break-after: always;" >
+</div>
 
 ## References
 

--- a/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -18,7 +18,6 @@ The following considerations apply:
 
 3. The effectiveness of the protection should always be verified by a human expert with experience in testing the particular types of anti-tampering and obfuscation used (see also the "reverse engineering" and "assessing software protections" chapters in the Mobile Security Testing Guide).
 
-
 ### Impede Dynamic Analysis and Tampering
 
 | # | MSTG-ID | Description | R |


### PR DESCRIPTION
I think this one should fix it. There's a difference between single and double line when gitbook interprets the html.

```
<div style="page-break-after: always;" >
</div>
```
vs

```<div style="page-break-after: always;" ></div>```

If this one works, I'll update the other languages.