### PR TITLE
Updated OWASP Mobile Top 10 links to point to the new website.

### DIFF
--- a/Document-de/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-de/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -35,7 +35,7 @@ Die Anforderungen für MASVS-L1 und MASVS-L2 sind nachfolgend aufgelistet.
 
 Für weitere Informationen:
 
-- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP Security Architecture cheat sheet - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - OWASP Threat Modeling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document-de/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-de/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -50,8 +50,8 @@ Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die A
 
 Weitere Informationen unter:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-de/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-de/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die A
 
 Weitere Informationen unter:
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-de/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-de/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -34,8 +34,8 @@ Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die A
 
 Weitere Informationen unter:
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-de/0x10-V5-Network_communication_requirements.md
+++ b/Document-de/0x10-V5-Network_communication_requirements.md
@@ -25,7 +25,7 @@ Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die A
 
 Weitere Informationen unter:
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-de/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-de/0x11-V6-Interaction_with_the_environment.md
@@ -32,8 +32,8 @@ Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die A
 
 Weitere Informationen unter:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-de/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-de/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -30,7 +30,7 @@ Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die A
 
 Weitere Informationen unter:
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-de/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-de/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -64,7 +64,7 @@ Der OWASP Mobile Security Testing Guide bietet detaillierte Anleitungen um die A
 
 Weitere Informationen unter:
 
-- OWASP Mobile Top 10: M8 (Code Tampering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 (Code Tampering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - OWASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-de/0x91-Appendix-B_References.md
+++ b/Document-de/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@ Die folgenden OWASP Projekte könnten für Anwender dieses Standards nützlich s
 
 - OWASP Mobile Security Project - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - OWASP Mobile Security Testing Guide - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- OWASP Mobile Top 10 Risks - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- OWASP Mobile Top 10 Risks - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP Reverse Engineering and Code Modification Prevention - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 Die folgenden Webseiten könnten ebenfalls für Anwender dieses Standards nützlich sein:

--- a/Document-es/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-es/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -35,7 +35,7 @@ A continuación, se enumeran los requerimientos para MASVS-L1 y MASVS-L2.
 
 Para más información, ver también:
 
-- OWASP Top 10 Móvil: M10 (Funcionalidades Extrañas) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Top 10 Móvil: M10 (Funcionalidades Extrañas) - <hhttps://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - "Cheat Sheet" de Arquitectura de Seguridad en Aplicaciones (OWASP) - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - Modelado de Amenazas (OWASP) - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - "Cheat Sheet" del Ciclo de Vida del Desarrollo Software Seguro (OWASP) - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document-es/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-es/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -51,8 +51,8 @@ La Guía de Pruebas de Seguridad Móvil de OWASP proporciona instrucciones detal
 
 Para más información, ver también:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-es/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-es/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ La Guía de Pruebas de Seguridad Móvil de OWASP proporciona instrucciones detal
 
 Para más información, ver también:
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-es/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-es/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -34,8 +34,8 @@ La Guía de Pruebas de Seguridad Móvil de OWASP proporciona instrucciones detal
 
 Para más información, ver también:
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-es/0x10-V5-Network_communication_requirements.md
+++ b/Document-es/0x10-V5-Network_communication_requirements.md
@@ -27,7 +27,7 @@ La Guía de Pruebas de Seguridad Móvil de OWASP proporciona instrucciones detal
 
 Para más información, ver también:
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-es/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-es/0x11-V6-Interaction_with_the_environment.md
@@ -32,8 +32,8 @@ La Guía de Pruebas de Seguridad Móvil de OWASP proporciona instrucciones detal
 
 Para más información, ver también:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-es/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-es/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -30,7 +30,7 @@ La Guía de Pruebas de Seguridad Móvil de OWASP proporciona instrucciones detal
 
 Para más información, ver también:
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-es/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-es/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -66,7 +66,7 @@ La Guía de Pruebas de Seguridad Móvil de OWASP proporciona instrucciones detal
 
 Para más información, ver también:
 
-- OWASP Top 10 Móvil: M8 (Modificación de Código) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Top 10 Móvil: M9 (Ingeniería Inversa) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Top 10 Móvil: M8 (Modificación de Código) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Top 10 Móvil: M9 (Ingeniería Inversa) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - Amenazas de Ingeniería Inversa (OWASP) - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - Ingeniería Inversa y Prevención de Modificación de Código (OWASP) - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-es/0x91-Appendix-B_References.md
+++ b/Document-es/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@ Los siguientes proyectos de OWASP serán probablemente de utilidad para los usua
 
 - Proyecto de Seguridad Móvil de OWASP - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - Guía de Pruebas de Seguridad Móvil OWASP - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- Top 10 de Riesgos Móviles de OWASP - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- Top 10 de Riesgos Móviles de OWASP - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - Ingeniería Inversa y Prevención de Modificación de Código de OWASP - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 También los siguientes sitios web serán probablemente de utilidad para los usuarios de este estándar:

--- a/Document-fr/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-fr/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -32,7 +32,7 @@ Les exigences pour MASVS-L1 et MASVS-L2 sont listées ci-dessous.
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M10 (Fonctions superflues) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (Fonctions superflues) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP Security Architecture cheat sheet - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - OWASP Thread modelling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document-fr/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-fr/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -51,8 +51,8 @@ Le Mobile Security Testing Guide de l'OWASP donne des instructions détaillées 
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-fr/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-fr/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ Le Mobile Security Testing Guide de l'OWASP donne des instructions détaillées 
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-fr/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-fr/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -33,8 +33,8 @@ Le Mobile Security Testing Guide de l'OWASP (guide de test de la Sécurité mobi
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-fr/0x10-V5-Network_communication_requirements.md
+++ b/Document-fr/0x10-V5-Network_communication_requirements.md
@@ -28,7 +28,7 @@ Le Mobile Security Testing Guide de l'OWASP (guide de test de la Sécurité mobi
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-fr/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-fr/0x11-V6-Interaction_with_the_environment.md
@@ -32,8 +32,8 @@ Le Mobile Security Testing Guide de l'OWASP (guide de test de la Sécurité mobi
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-fr/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-fr/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -29,7 +29,7 @@ Le Mobile Security Testing Guide de l'OWASP (guide de test de la Sécurité mobi
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-fr/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-fr/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -65,7 +65,7 @@ Le Mobile Security Testing Guide de l'OWASP (guide de test de la Sécurité mobi
 
 Pour de plus amples informations, il est possible de consulter aussi :
 
-- OWASP Mobile Top 10: M8 (Modification du Code) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 (Rétro-Ingénierie) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 (Modification du Code) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 (Rétro-Ingénierie) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - OWASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-fr/0x91-Appendix-B_References.md
+++ b/Document-fr/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@ Les projets de l'OWASP suivants sont susceptibles d'être utiles aux utilisateur
 
 - OWASP Mobile Security Project - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - OWASP Mobile Security Testing Guide - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- OWASP Mobile Top 10 Risks - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- OWASP Mobile Top 10 Risks - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP Reverse Engineering and Code Modification Prevention - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 De la même manière, les sites web suivants sont susceptibles d'être utiles aux utilisateurs / ceux qui vont adopter ce standard :

--- a/Document-ja/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ja/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -32,7 +32,7 @@ MASVS-L1 および MASVS-L2 の要件を以下に記します。
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP Security Architecture cheat sheet - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - OWASP Threat modelling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document-ja/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-ja/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -48,8 +48,8 @@ OWASP モバイルセキュリティテストガイドでは、このセクシ�
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-ja/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-ja/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ OWASP モバイルセキュリティテストガイドでは、このセクシ�
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-ja/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-ja/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -34,8 +34,8 @@ OWASP モバイルセキュリティテストガイドでは、このセクシ�
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-ja/0x10-V5-Network_communication_requirements.md
+++ b/Document-ja/0x10-V5-Network_communication_requirements.md
@@ -28,7 +28,7 @@ OWASP モバイルセキュリティテストガイドでは、このセクシ�
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-ja/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-ja/0x11-V6-Interaction_with_the_environment.md
@@ -31,8 +31,8 @@ OWASP モバイルセキュリティテストガイドでは、このセクシ�
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-ja/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-ja/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -30,7 +30,7 @@ OWASP モバイルセキュリティテストガイドでは、上記の要件�
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-ja/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-ja/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -66,7 +66,7 @@ OWASP モバイルセキュリティテストガイドでは、このセクシ�
 
 詳しくは以下の情報を参照してください。
 
-- OWASP Mobile Top 10: M8 (Code Tampering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 (Code Tampering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - OWASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-ja/0x91-Appendix-B_References.md
+++ b/Document-ja/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@
 
 - OWASP Mobile Security Project - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - OWASP Mobile Security Testing Guide - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- OWASP Mobile Top 10 Risks - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- OWASP Mobile Top 10 Risks - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP Reverse Engineering and Code Modification Prevention - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 同様に以下のWebサイトはこの標準のユーザーや採用者にとって最も役に立つものです。

--- a/Document-ko/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ko/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -32,7 +32,7 @@ MASVS-L1 및 MASVS-L2의 요구사항은 다음과 같습니다.
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP Security Architecture cheat sheet - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - OWASP Threat modelling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document-ko/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-ko/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -48,8 +48,8 @@ OWASP 모바일 보안 테스트 안내서(MSTG)는 이 섹션에 나열된 요�
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-ko/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-ko/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ OWASP 모바일 보안 테스트 안내서(MSTG)는 이 섹션에 나열된 요�
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-ko/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-ko/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -34,8 +34,8 @@ OWASP 모바일 보안 테스트 안내서(MSTG)는 이 섹션에 나열된 요�
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-ko/0x10-V5-Network_communication_requirements.md
+++ b/Document-ko/0x10-V5-Network_communication_requirements.md
@@ -25,7 +25,7 @@ OWASP 모바일 보안 테스트 안내서(MSTG)는 이 섹션에 나열된 요�
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-ko/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-ko/0x11-V6-Interaction_with_the_environment.md
@@ -31,8 +31,8 @@ OWASP 모바일 보안 테스트 안내서(MSTG)는 이 섹션에 나열된 요�
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-ko/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-ko/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -27,12 +27,12 @@ OWASP 모바일 보안 테스트 안내서(MSTG)는 이 섹션에 나열된 요�
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 119 (Improper Restriction of Operations within the Bounds of a Memory Buffer) - <https://cwe.mitre.org/data/definitions/119.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 388 (7PK - Errors) - <https://cwe.mitre.org/data/definitions/388.html>
 - CWE 489 (Leftover Debug Code) - <https://cwe.mitre.org/data/definitions/489.html>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-ko/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-ko/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -66,7 +66,7 @@ OWASP 모바일 보안 테스트 안내서(MSTG)는 이 섹션에 나열된 요�
 
 자세한 내용은 다음을 참조하십시오:
 
-- OWASP Mobile Top 10: M8 (Code Tampering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 (Code Tampering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - OWASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-ko/0x91-Appendix-B_References.md
+++ b/Document-ko/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@
 
 - OWASP Mobile Security Project - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - OWASP Mobile Security Testing Guide - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- OWASP Mobile Top 10 Risks - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- OWASP Mobile Top 10 Risks - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP Reverse Engineering and Code Modification Prevention - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 마찬가지로 이 표준의 사용자 및 채택자에게 가장 유용할 수 있는 웹 사이트는 다음과 같습니다.

--- a/Document-ru/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ru/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -32,7 +32,7 @@
 
 Для дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP Security Architecture cheat sheet - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - OWASP Thread modelling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document-ru/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-ru/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -51,8 +51,8 @@ OWASP MSTG содержит подробные инструкции по вер�
 
 Для получения дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-ru/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-ru/0x08-V3-Cryptography_Verification_Requirements.md
@@ -31,7 +31,7 @@ OWASP MSTG содержит подробные инструкции по вер�
 
 Для получения дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-ru/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-ru/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -33,8 +33,8 @@ OWASP MSTG содержит подробные инструкции по вер�
 
 Для получения дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-ru/0x10-V5-Network_communication_requirements.md
+++ b/Document-ru/0x10-V5-Network_communication_requirements.md
@@ -28,7 +28,7 @@ OWASP MSTG содержит подробные инструкции по вер�
 
 Для получения дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-ru/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-ru/0x11-V6-Interaction_with_the_environment.md
@@ -32,8 +32,8 @@ OWASP MSTG содержит подробные инструкции по вер�
 
 Для получения дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-ru/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-ru/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -27,7 +27,7 @@ OWASP MSTG содержит подробные инструкции по про�
 
 Для получения дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-ru/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-ru/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -66,7 +66,7 @@ OWASP MSTG содержит подробные инструкции по вер�
 
 Для получения дополнительной информации смотрите также:
 
-- OWASP Mobile Top 10: M8 (Фальсификация кода) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 (Обратная разработка) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 (Фальсификация кода) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 (Обратная разработка) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - ОWASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-ru/0x91-Appendix-B_References.md
+++ b/Document-ru/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@
 
 - OWASP Mobile Security Project - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - OWASP Mobile Security Testing Guide - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- OWASP Mobile Top 10 Risks - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- OWASP Mobile Top 10 Risks - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP Reverse Engineering and Code Modification Prevention - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 Следующие веб-сайты также будут полезны для пользователей/последователей этого стандарта:

--- a/Document-zhcn/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-zhcn/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -32,7 +32,7 @@
 
 更多信息，另请参见：
 
-- OWASP Mobile Top 10: M10 (外部功能) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (外部功能) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP 威胁建模 - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP 安全SDLC速查表 - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>

--- a/Document-zhcn/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-zhcn/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -48,8 +48,8 @@ OWASP移动安全测试指南对本章节中列出的验证要求都提供了的
 
 更多信息，另请参见:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-zhcn/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-zhcn/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ OWASP 移动安全测试指南提供了验证本节中列出的要求的详细�
 
 测试密码学:
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-zhcn/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-zhcn/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -34,8 +34,8 @@ OWASP移动安全性测试指南提供了验证上面列出的要求的详细说
 
 有关更多信息，另请参见：
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-zhcn/0x10-V5-Network_communication_requirements.md
+++ b/Document-zhcn/0x10-V5-Network_communication_requirements.md
@@ -25,7 +25,7 @@ OWASP移动安全测试指南提供了验证本节中列出的要求的详细说
 
 有关更多信息，另请参见：
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-zhcn/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-zhcn/0x11-V6-Interaction_with_the_environment.md
@@ -32,8 +32,8 @@ OWASP移动安全测试指南提供了验证本节中列出的要求的详细说
 
 有关详细信息，请参阅：
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-zhcn/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-zhcn/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -28,7 +28,7 @@ OWASP 移动安全测试指南提供了验证上述要求的详细说明。
 
 有关详细信息，请参阅：
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-zhcn/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-zhcn/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -66,7 +66,7 @@ OWASP 移动安全测试指南提供了验证本节中列出的要求的详细�
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M8 - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - OWASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-zhcn/0x91-Appendix-B_References.md
+++ b/Document-zhcn/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@
 
 - OWASP 移动安全项目 - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - OWASP 移动安全测试指南 - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- OWASP 移动应用十大风险 - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- OWASP 移动应用十大风险 - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP 逆向工程以及程序代码修改的预防 - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 相同的，下列网站可以帮助使用者/采纳者更了解这个标准：

--- a/Document-zhtw/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-zhtw/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -29,7 +29,7 @@
 
 更多資訊請參閱：
 
-- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP Security Architecture cheat sheet - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - OWASP Thread modelling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document-zhtw/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document-zhtw/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -48,8 +48,8 @@ OWASP 行動安全檢測指南列出相關要求，並且相關章節中有詳�
 
 更多相關信息，另請參閱：
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document-zhtw/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document-zhtw/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ OWASP 行動安全檢測指南列出相關要求，並且相關章節中有詳�
 
 更多相關信息，另請參閱：
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document-zhtw/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document-zhtw/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -33,8 +33,8 @@ OWASP Mobile Security Testing Guide 提供了有關驗證本章節中列出的�
 
 更多資訊請參閱：
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document-zhtw/0x10-V5-Network_communication_requirements.md
+++ b/Document-zhtw/0x10-V5-Network_communication_requirements.md
@@ -24,7 +24,7 @@ OWASP Mobile Security Testing Guide 提供了有關驗證本章節中列出的�
 
 更多相關信息，另請參閱：
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document-zhtw/0x11-V6-Interaction_with_the_environment.md
+++ b/Document-zhtw/0x11-V6-Interaction_with_the_environment.md
@@ -29,8 +29,8 @@ OWASP Mobile Security Testing Guide 提供了有關驗證本章節中列出的�
 
 更多資訊請參閱：
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document-zhtw/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document-zhtw/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -27,7 +27,7 @@ OWASP 行動應用安全性測試指南針對此章節所列出的認證要，�
 
 更多資訊，請參考：
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document-zhtw/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document-zhtw/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -69,7 +69,7 @@ OWASP Mobile Security Testing Guide 提供了有關驗證本章節中列出的�
 
 更多資訊請參閱：
 
-- OWASP Mobile Top 10: M8 (Code Tampering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 (Code Tampering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - WASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document-zhtw/0x91-Appendix-B_References.md
+++ b/Document-zhtw/0x91-Appendix-B_References.md
@@ -6,7 +6,7 @@
 - OWASP 行動應用安全測試指南
 [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
 - OWASP 行動應用 Top 10 風險
- [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+ [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP 逆向工程及程式碼編修防護
 [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 

--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -32,7 +32,7 @@ The requirements for MASVS-L1 and MASVS-L2 are listed below.
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality>
+- OWASP Mobile Top 10: M10 (Extraneous Functionality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP Security Architecture cheat sheet - <https://www.owasp.org/index.php/Application_Security_Architecture_Cheat_Sheet>
 - OWASP Threat modelling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>

--- a/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
+++ b/Document/0x07-V2-Data_Storage_and_Privacy_requirements.md
@@ -48,8 +48,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M2 (Insecure Data Storage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage>
 - CWE 117 (Improper Output Neutralization for Logs) - <https://cwe.mitre.org/data/definitions/117.html>
 - CWE 200 (Information Exposure) - <https://cwe.mitre.org/data/definitions/200.html>
 - CWE 276 (Incorrect Default Permissions) - <https://cwe.mitre.org/data/definitions/276.html>

--- a/Document/0x08-V3-Cryptography_Verification_Requirements.md
+++ b/Document/0x08-V3-Cryptography_Verification_Requirements.md
@@ -28,7 +28,7 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography>
+- OWASP Mobile Top 10: M5 (Insufficient Cryptography) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography>
 - CWE 310 (Cryptographic Issues) - <https://cwe.mitre.org/data/definitions/310.html>
 - CWE 321 (Use of Hard-coded Cryptographic Key) - <https://cwe.mitre.org/data/definitions/321.html>
 - CWE 326 (Inadequate Encryption Strength) - <https://cwe.mitre.org/data/definitions/326.html>

--- a/Document/0x09-V4-Authentication_and_Session_Management_Requirements.md
+++ b/Document/0x09-V4-Authentication_and_Session_Management_Requirements.md
@@ -34,8 +34,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication>
-- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M6-Insecure_Authorization>
+- OWASP Mobile Top 10: M4 (Insecure Authentication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication>
+- OWASP Mobile Top 10: M6 (Insecure Authorization) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization>
 - CWE 287 (Improper Authentication) - <https://cwe.mitre.org/data/definitions/287.html>
 - CWE 307 (Improper Restriction of Excessive Authentication Attempts) - <https://cwe.mitre.org/data/definitions/307.html>
 - CWE 308 (Use of Single-factor Authentication) - <https://cwe.mitre.org/data/definitions/308.html>

--- a/Document/0x10-V5-Network_communication_requirements.md
+++ b/Document/0x10-V5-Network_communication_requirements.md
@@ -25,7 +25,7 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M3-Insecure_Communication>
+- OWASP Mobile Top 10: M3 (Insecure Communication) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication>
 - CWE 295 (Improper Certificate Validation) - <https://cwe.mitre.org/data/definitions/295.html>
 - CWE 296 (Improper Following of a Certificate's Chain of Trust) - <https://cwe.mitre.org/data/definitions/296.html>
 - CWE 297 (Improper Validation of Certificate with Host Mismatch) - <https://cwe.mitre.org/data/definitions/297.html>

--- a/Document/0x11-V6-Interaction_with_the_environment.md
+++ b/Document/0x11-V6-Interaction_with_the_environment.md
@@ -31,8 +31,8 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage>
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M1 (Improper Platform Usage) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 79 (Improper Neutralization of Input During Web Page Generation) - <https://cwe.mitre.org/data/definitions/79.html>
 - CWE 200 (Information Leak / Disclosure) - <https://cwe.mitre.org/data/definitions/200.html>

--- a/Document/0x12-V7-Code_quality_and_build_setting_requirements.md
+++ b/Document/0x12-V7-Code_quality_and_build_setting_requirements.md
@@ -27,7 +27,7 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- OWASP Mobile Top 10: M7 (Poor Code Quality) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 - CWE 20 (Improper Input Validation) - <https://cwe.mitre.org/data/definitions/20.html>
 - CWE 89 (Improper Neutralization of Special Elements used in an SQL Command) - <https://cwe.mitre.org/data/definitions/89.html>
 - CWE 95 (Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')) - <https://cwe.mitre.org/data/definitions/95.html>

--- a/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
+++ b/Document/0x15-V8-Resiliency_Against_Reverse_Engineering_Requirements.md
@@ -66,7 +66,7 @@ The OWASP Mobile Security Testing Guide provides detailed instructions for verif
 
 For more information, see also:
 
-- OWASP Mobile Top 10: M8 (Code Tampering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M8-Code_Tampering>
-- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering>
+- OWASP Mobile Top 10: M8 (Code Tampering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m8-code-tampering>
+- OWASP Mobile Top 10: M9 (Reverse Engineering) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering>
 - OWASP Reverse Engineering Threats - <https://www.owasp.org/index.php/Technical_Risks_of_Reverse_Engineering_and_Unauthorized_Code_Modification>
 - OWASP Reverse Engineering and Code Modification Prevention - <https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project>

--- a/Document/0x91-Appendix-B_References.md
+++ b/Document/0x91-Appendix-B_References.md
@@ -4,7 +4,7 @@ The following OWASP projects are most likely to be useful to users/adopters of t
 
 - OWASP Mobile Security Project - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Project](https://www.owasp.org/index.php/OWASP_Mobile_Security_Project)
 - OWASP Mobile Security Testing Guide - [https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide)
-- OWASP Mobile Top 10 Risks - [https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks](https://www.owasp.org/index.php/Projects/OWASP_Mobile_Security_Project_-_Top_Ten_Mobile_Risks)
+- OWASP Mobile Top 10 Risks - [https://owasp.org/www-project-mobile-top-10/](https://owasp.org/www-project-mobile-top-10/)
 - OWASP Reverse Engineering and Code Modification Prevention - [https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project](https://www.owasp.org/index.php/OWASP_Reverse_Engineering_and_Code_Modification_Prevention_Project)
 
 Similarly, the following web sites are most likely to be useful to users/adopters of this standard:


### PR DESCRIPTION
Hello,

Recently the OWASP website was update to use a new template, but the OWASP Mobile Top 10 website had not been migrated over. 

After doing so I am now updating all old links for the MASVS and MSTG.

Please let me know if I need to make any additional changes. Thanks!