### PR TITLE
Ensure same plugin is being used 

### DIFF
--- a/.github/workflows/checkLinks.yml
+++ b/.github/workflows/checkLinks.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@0.6.0
+        uses: gaurav-nelson/github-action-markdown-link-check@0f8975d33c4555ebd148e2cd39176b3add9639dc
         with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'

--- a/.github/workflows/checkLint.yml
+++ b/.github/workflows/checkLint.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v1.1.1
+        uses: nosborn/github-action-markdown-cli@9fc95163471d6460c35cccad13645912aaa25d5f
         with:
           files: Document Document-de Document-es Document-fr Document-ja Document-ko Document-ru Document-zhtw Document-zhcn
           config_file: ".markdownlint.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate Korean docs
         run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc masvs-generator '/pandoc_makedocs.sh Document-ko ${{ steps.get_version.outputs.VERSION }}'
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
         if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: tools/RECENT_CHANGES.TXT


### PR DESCRIPTION
Given that some of the plugins have access to our tokens/secrets, I need to make sure that the right version of teh plugin is being used. This is an intermediary step.
Todo: migrate to own plugins and upstream vetting
