### PR TITLE
Fix CSV inconsistency

### DIFF
--- a/tools/masvs.py
+++ b/tools/masvs.py
@@ -64,8 +64,8 @@ class MASVS:
                         req['text'] = m.group(3).strip()
                         req['category'] = m.group(2).replace(u"\u2011", "-")
                         if m.group(5):
-                            req['L1'] = len(m.group(4)) > 0
-                            req['L2'] = len(m.group(5)) > 0
+                            req['L1'] = len(m.group(4).strip()) > 0
+                            req['L2'] = len(m.group(5).strip()) > 0
                             req['R'] = False
                         else:
                             req['R'] = True


### PR DESCRIPTION
Whitespace should be ignored when checking if there is a check or not. The two requirements that are giving errors contain a single space character in the L1 field, which should be ignored. This solution seems better than enforcing there can't be whitespace in the field.

This fixes #408 
