### PR TITLE
Updated ARCH links with a new link to NIST SP 800-57

### DIFF
--- a/Document-de/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-de/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,5 +33,5 @@ Für weitere Informationen:
 - OWASP Threat Modeling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 (Recommendation for Key Management) - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 (Recommendation for Key Management) - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-es/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-es/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,5 +33,5 @@ Para más información, ver también:
 - Modelado de Amenazas (OWASP) - <https://owasp.org/www-community/Application_Threat_Modeling>
 - "Cheat Sheet" del Ciclo de Vida del Desarrollo Software Seguro (OWASP) - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 (Recomendación de Gestión de Claves) - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 (Recomendación de Gestión de Claves) - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-fa/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-fa/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -35,7 +35,7 @@
 - مدلسازی تهدید (OWASP) - <https://owasp.org/www-community/Application_Threat_Modeling>
 - راهنمای چرخه‌ی حیات توسعه‌ی امن نرم‌افزار (OWASP) - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - راهنمای چرخه‌ی حیات توسعه‌ی نرم‌افزار مایکروسافت - <https://www.microsoft.com/en-us/sdl/>
-- استاندارد (NIST SP 800-57) - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- استاندارد (NIST SP 800-57) - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - (security.txt) - <https://securitytxt.org>
 
 </div>

--- a/Document-fr/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-fr/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,5 +33,5 @@ Pour de plus amples informations, il est possible de consulter aussi :
 - OWASP Thread modelling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-hi/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-hi/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -32,5 +32,5 @@ MASVS-L1 और MASVS-L2 की आवश्यकताएं नीचे स�
 - OWASP मोबाइल टॉप 10: M10 (एक्सट्रोनस फंक्शनलिटी) - <https://owasp.org/www-project-mobile-top-10/2016-risks/m10-extraneous-functionality>
 - OWASP थ्रेट मॉडलिंग - <https://owasp.org/www-community/Application_Threat_Modeling>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-ja/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ja/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,5 +33,5 @@ MASVS-L1 および MASVS-L2 の要件を以下に記します。
 - OWASP Threat modelling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-ko/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ko/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,5 +33,5 @@ MASVS-L1 및 MASVS-L2의 요구사항은 다음과 같습니다.
 - OWASP Threat modelling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-ptbr/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ptbr/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -34,5 +34,5 @@ Para mais informações, consulte também (em inglês):
 - OWASP Threat modelling - <https://www.owasp.org/index.php/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://www.owasp.org/index.php/Secure_SDLC_Cheat_Sheet>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-ptpt/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ptpt/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -34,5 +34,5 @@ Para mais informação, ver também:
 - OWASP Threat modelling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-ru/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-ru/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -34,5 +34,5 @@
 - OWASP Threat modelling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 (Recommendation for Key Management) - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 (Recommendation for Key Management) - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-zhcn/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-zhcn/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,5 +33,5 @@
 - OWASP 威胁建模 - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP 安全SDLC速查表 - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>

--- a/Document-zhtw/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document-zhtw/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,4 +33,5 @@
 - OWASP Thread modelling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
+- security.txt - <https://securitytxt.org/>

--- a/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
+++ b/Document/0x06-V1-Architecture_design_and_threat_modelling_requireme.md
@@ -33,5 +33,5 @@ For more information, see also:
 - OWASP Threat modelling - <https://owasp.org/www-community/Application_Threat_Modeling>
 - OWASP Secure SDLC Cheat Sheet - <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets_excluded/Secure_SDLC_Cheat_Sheet.md>
 - Microsoft SDL - <https://www.microsoft.com/en-us/sdl/>
-- NIST SP 800-57 - <http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57-Part1-revised2_Mar08-2007.pdf>
+- NIST SP 800-57 - <https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final>
 - security.txt - <https://securitytxt.org/>


### PR DESCRIPTION
Updated the link to NIST SP 800-57. Now it points not to the exact version but the `/final` one. It should not get outdated as fast as previous links. 


- [x] Your PR is linked to an issue.
- [x] Your PR follows the [contribution guidelines](https://github.com/OWASP/owasp-masvs/blob/master/CONTRIBUTING.md "Contribution guidelines")
- [ ] All links are valid and use HTTPS and have been formatted as [TEXT](URL “NAME”) - _I think it will not be consistent to do that_

This PR closes #501 .
