### PR TITLE
Add Open in vscode Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://github.com/OWASP/owasp-masvs/releases/download/v1.3/OWASP_MASVS-v1.3-en.pdf"><img width="25%" align="right" style="float: right;" src="Document/images/masvs-mini-cover.png"></a>
 
-# OWASP Mobile Application Security Verification Standard [![Twitter Follow](https://img.shields.io/twitter/follow/OWASP_MSTG.svg?style=social&label=Follow)](https://twitter.com/OWASP_MSTG)
+# OWASP Mobile Application Security Verification Standard [![Twitter Follow](https://img.shields.io/twitter/follow/OWASP_MSTG.svg?style=social&label=Follow)](https://twitter.com/OWASP_MSTG) [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/OWASP/owasp-masvs)
 
 [![Creative Commons License](https://licensebuttons.net/l/by-sa/4.0/88x31.png)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
 [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://owasp.org/projects/)


### PR DESCRIPTION
It will show a badge to directly open the project in vscode.

ref: https://open.vscode.dev/

<img width="1105" alt="Screenshot 2021-07-12 at 19 08 03" src="https://user-images.githubusercontent.com/29175115/125328350-83982680-e344-11eb-9a24-0bd6173540d6.png">

<img width="1229" alt="open-vscode" src="https://user-images.githubusercontent.com/29175115/125328232-5cd9f000-e344-11eb-8ab5-c13d808e30a2.png">


