### PR TITLE
Fix pandocker build for all languages

### DIFF
--- a/.github/workflows/docgenerator.yml
+++ b/.github/workflows/docgenerator.yml
@@ -5,7 +5,7 @@ on: [push, workflow_dispatch]
 jobs:
 
 ##
-## Use `pandocker-tag: TAG=stable-full` for langs that require the special fonts (Russian, Chinese, etc.)
+## Use `pandocker-tag: TAG=latest-ubuntu-full` for langs that require the special fonts (Russian, Chinese, etc.)
 ##
 
   en:
@@ -56,7 +56,7 @@ jobs:
       folder: Document-hi
       language: Hindi
       lang: hi
-      pandocker-tag: TAG=stable-full
+      pandocker-tag: TAG=latest-ubuntu-full
 
   ja:
     uses: OWASP/owasp-masvs/.github/workflows/doc-gen-reusable.yml@master
@@ -64,7 +64,7 @@ jobs:
       folder: Document-ja
       language: Japanese
       lang: ja
-      pandocker-tag: TAG=stable-full
+      pandocker-tag: TAG=latest-ubuntu-full
 
   ko:
     uses: OWASP/owasp-masvs/.github/workflows/doc-gen-reusable.yml@master
@@ -72,7 +72,7 @@ jobs:
       folder: Document-ko
       language: Korean
       lang: ko
-      pandocker-tag: TAG=stable-full
+      pandocker-tag: TAG=latest-ubuntu-full
 
   ru:
     uses: OWASP/owasp-masvs/.github/workflows/doc-gen-reusable.yml@master
@@ -80,7 +80,7 @@ jobs:
       folder: Document-ru
       language: Russian
       lang: ru
-      pandocker-tag: TAG=stable-full
+      pandocker-tag: TAG=latest-ubuntu-full
 
   fa:
     uses: OWASP/owasp-masvs/.github/workflows/doc-gen-reusable.yml@master
@@ -88,7 +88,7 @@ jobs:
       folder: Document-fa
       language: Persian
       lang: fa
-      pandocker-tag: TAG=stable-full
+      pandocker-tag: TAG=latest-ubuntu-full
       pandocker-template: LATEX_TEMPLATE=default # there's a bug for fa in the eisvogel template, we have to use default
 
   zhcn:
@@ -97,7 +97,7 @@ jobs:
       folder: Document-zhcn
       language: Simplified Chinese
       lang: zhcn
-      pandocker-tag: TAG=stable-full
+      pandocker-tag: TAG=latest-ubuntu-full
 
   zhtw:
     uses: OWASP/owasp-masvs/.github/workflows/doc-gen-reusable.yml@master
@@ -105,7 +105,7 @@ jobs:
       folder: Document-zhtw
       language: Traditional Chinese
       lang: zhtw
-      pandocker-tag: TAG=stable-full
+      pandocker-tag: TAG=latest-ubuntu-full
 
   export:
     runs-on: ubuntu-latest

--- a/tools/docker/latex-header.tex
+++ b/tools/docker/latex-header.tex
@@ -41,3 +41,7 @@
 %%\usepackage[space]{xeCJK}
 %%\setCJKmainfont{Noto Sans CJK {{CJK-LANG}}} %JP,SC,TC,KR
 %%\renewcommand\CJKglue{}% get proper linebreaking if spaces are provided
+
+%% Workaround for pandoc bug #8460
+%% https://github.com/jgm/pandoc/issues/8460
+\newenvironment{RTL}{\beginR}{\endR}

--- a/tools/docker/pandoc_makedocs.sh
+++ b/tools/docker/pandoc_makedocs.sh
@@ -8,7 +8,7 @@ VERSION=${2:-SNAPSHOT}
 
 # You can also use the environment variables below to adapt the build process
 IMG=${IMG:-dalibo/pandocker}
-TAG=${TAG:-stable} # /!\ use stable-full for non-european languages
+TAG=${TAG:-latest-ubuntu-full} # /!\ use stable-full for non-european languages
 LATEX_TEMPLATE=${LATEX_TEMPLATE:-eisvogel}
 TITLE=${TITLE:-OWASP Mobile Application Security Verification Standard ${VERSION}}
 

--- a/tools/docker/pandoc_makedocs.sh
+++ b/tools/docker/pandoc_makedocs.sh
@@ -8,7 +8,7 @@ VERSION=${2:-SNAPSHOT}
 
 # You can also use the environment variables below to adapt the build process
 IMG=${IMG:-dalibo/pandocker}
-TAG=${TAG:-latest-ubuntu-full} # /!\ use stable-full for non-european languages
+TAG=${TAG:-stable} # /!\ use stable-full for non-european languages
 LATEX_TEMPLATE=${LATEX_TEMPLATE:-eisvogel}
 TITLE=${TITLE:-OWASP Mobile Application Security Verification Standard ${VERSION}}
 


### PR DESCRIPTION
Upgrades `pandocker-tag` from `stable-full `to `latest-ubuntu-full`


Uses a workaround in Latex-Templates for a pandoc issue. See issue and discussion here: https://github.com/dalibo/pandocker/issues/234