### PR TITLE
Add MASVS-PRIVACY

### DIFF
--- a/Document/03-Using_the_MASVS.md
+++ b/Document/03-Using_the_MASVS.md
@@ -19,12 +19,13 @@ The standard is divided into various groups that represent the most critical are
 - **MASVS-PLATFORM:** Secure interaction with the underlying mobile platform and other installed apps.
 - **MASVS-CODE:** Security best practices for data processing and keeping the app up-to-date.
 - **MASVS-RESILIENCE:** Resilience to reverse engineering and tampering attempts.
+- **MASVS-PRIVACY:** Privacy controls to protect user privacy.
 
 Each of these control groups contains individual controls labeled **MASVS-XXXXX-Y**, which provide specific guidance on the particular security measures that need to be implemented to meet the standard.
 
-## Mobile Application Security Profiles
+## MAS Testing Profiles
 
-The MAS project has traditionally provided three verification levels (L1, L2 and R), which were revisited during the MASVS refactoring in 2023, and have been reworked as "security testing profiles" and moved over to the OWASP MASTG. These profiles are now aligned with the [NIST OSCAL (Open Security Controls Assessment Language)](https://pages.nist.gov/OSCAL/) standard, which is a comprehensive catalog of security controls that can be used to secure information systems.
+The MAS project has traditionally provided three verification levels (L1, L2 and R), which were revisited during the MASVS refactoring in 2023, and have been reworked as ["MAS Testing Profiles"](https://docs.google.com/document/d/1paz7dxKXHzAC9MN7Mnln1JiZwBNyg7Gs364AJ6KudEs/edit?usp=sharing) and moved over to the OWASP MASTG. These profiles are now aligned with the [NIST OSCAL (Open Security Controls Assessment Language)](https://pages.nist.gov/OSCAL/) standard, which is a comprehensive catalog of security controls that can be used to secure information systems.
 
 By aligning with OSCAL, the MASVS provides a more flexible and comprehensive approach to security testing. OSCAL provides a standard format for security control information, which allows for easier sharing and reuse of security controls across different systems and organizations. This allows for a more efficient use of resources and a more targeted approach to mobile app security testing.
 

--- a/Document/04-Assessment_and_Certification.md
+++ b/Document/04-Assessment_and_Certification.md
@@ -18,9 +18,12 @@ A certifying organization must include in any report the scope of the verificati
 
 ### Using the OWASP Mobile Application Security Testing Guide (MASTG)
 
-The OWASP MASTG is a manual for testing the security of mobile apps. It describes the technical processes for verifying the controls listed in the MASVS. The MASTG includes a list of test cases, each of which map to a control in the MASVS. While the MASVS controls are high-level and generic, the MASTG provides in-depth recommendations and testing procedures on a per-mobile-OS basis.
+The [OWASP MASTG](https://mas.owasp.org/MASTG/) is a manual for testing the security of mobile apps. It describes the technical processes for verifying the controls listed in the MASVS. The MASTG includes a list of test cases, each of which map to a control in the MASVS. While the MASVS controls are high-level and generic, the MASTG provides in-depth recommendations and testing procedures on a per-mobile-OS basis.
 
-Testing the app's remote endpoints is not covered in the MASTG. The [OWASP Web Security Testing Guide (WSTG)](https://owasp.org/www-project-web-security-testing-guide/) is a comprehensive guide with detailed technical explanation and guidance for testing the security of web applications and web services holistically and can be used in addition to other relevant resources to complement the mobile app security testing exercise.
+Testing the app's remote endpoints is not covered in the MASTG. For example:
+
+- **Remote Endpoints**: The [OWASP Web Security Testing Guide (WSTG)](https://owasp.org/www-project-web-security-testing-guide/) is a comprehensive guide with detailed technical explanation and guidance for testing the security of web applications and web services holistically and can be used in addition to other relevant resources to complement the mobile app security testing exercise.
+- **Internet of Things (IoT)**: The [OWASP IoT Security Testing Guide (ISTG)](https://owasp.org/owasp-istg/) provides a comprehensive methodology for penetration tests in the IoT field offering flexibility to adapt innovations and developments on the IoT market while still ensuring comparability of test results. The guide provides an understanding of communication between manufacturers and operators of IoT devices as well as penetration testing teams that's facilitated by establishing a common terminology.
 
 ### The Role of Automated Security Testing Tools
 

--- a/Document/12-MASVS-PRIVACY.md
+++ b/Document/12-MASVS-PRIVACY.md
@@ -1,0 +1,11 @@
+# MASVS-PRIVACY: Privacy
+
+The main goal of MASVS-PRIVACY is to provide a **baseline for user privacy**. It is not intended to cover all aspects of user privacy, especially when other standards and regulations such as ENISA or the GDPR already do that. We focus on the app itself, looking at what can be tested using information that's publicly available or found within the app through methods like static or dynamic analysis.
+
+While some associated tests can be automated, others necessitate manual intervention due to the nuanced nature of privacy. For example, if an app collects data that it didn't mention in the app store or its privacy policy, it takes careful manual checking to spot this.
+
+> **Note on "Data Collection and Sharing"**:For the MASTG tests, we treat "Collect" and "Share" in a unified manner. This means that whether the app is sending data to another server or transferring it to another app on the device, we view it as data that's potentially leaving the user's control. Validating what happens to the data on remote endpoints is challenging and often not feasible due to access restrictions and the dynamic nature of server-side operations. Therefore, this issue is outside of the scope of the MASVS.
+
+**IMPORTANT DISCLAIMER**:
+
+MASVS-PRIVACY is not intended to serve as an exhaustive or exclusive reference. While it provides valuable guidance on app-centric privacy considerations, it should never replace comprehensive assessments, such as a Data Protection Impact Assessment (DPIA) mandated by the General Data Protection Regulation (GDPR) or other pertinent legal and regulatory frameworks. Stakeholders are strongly advised to undertake a holistic approach to privacy, integrating MASVS-PRIVACY insights with broader assessments to ensure comprehensive data protection compliance. Given the specialized nature of privacy regulations and the complexity of data protection, these assessments are best conducted by privacy experts rather than security experts.

--- a/controls/MASVS-PRIVACY-1.md
+++ b/controls/MASVS-PRIVACY-1.md
@@ -1,0 +1,13 @@
+# MASVS-PRIVACY-1
+
+## Control
+
+The app minimizes access to sensitive data and resources.
+
+## Description
+
+Apps should only request access to the data they absolutely need for their functionality and always with informed consent from the user. This control ensures that apps practice data minimization and restricts access control, reducing the potential impact of data breaches or leaks.
+
+Furthermore, apps should share data with third parties only when necessary, and this should include enforcing that third-party SDKs operate based on user consent, not by default or without it. Apps should prevent third-party SDKs from ignoring consent signals or from collecting data before consent is confirmed.
+
+Additionally, apps should be aware of the 'supply chain' of SDKs they incorporate, ensuring that no data is unnecessarily passed down their chain of dependencies. This end-to-end responsibility for data aligns with recent SBOM regulatory requirements, making apps more accountable for their data practices.

--- a/controls/MASVS-PRIVACY-2.md
+++ b/controls/MASVS-PRIVACY-2.md
@@ -1,0 +1,11 @@
+# MASVS-PRIVACY-2
+
+## Control
+
+The app prevents identification of the user.
+
+## Description
+
+Protecting user identity is crucial. This control emphasizes the use of unlinkability techniques like data abstraction, anonymization and pseudonymization to prevent user identification and tracking.
+
+Another key aspect addressed by this control is to establish technical barriers when employing complex 'fingerprint-like' signals (e.g. device IDs, IP addresses, behavioral patterns) for specific purposes. For instance, a fingerprint used for fraud detection should be isolated and not repurposed for audience measurement in an analytics SDK. This ensures that each data stream serves its intended function without risking user privacy.

--- a/controls/MASVS-PRIVACY-3.md
+++ b/controls/MASVS-PRIVACY-3.md
@@ -1,0 +1,9 @@
+# MASVS-PRIVACY-3
+
+## Control
+
+The app is transparent about data collection and usage.
+
+## Description
+
+Users have the right to know how their data is being used. This control ensures that apps provide clear information about data collection, storage, and sharing practices, including any behavior a user wouldn't reasonably expect, such as background data collection. Apps should also adhere to platform guidelines on data declarations.

--- a/controls/MASVS-PRIVACY-4.md
+++ b/controls/MASVS-PRIVACY-4.md
@@ -1,0 +1,9 @@
+# MASVS-PRIVACY-4
+
+## Control
+
+The app offers user control over their data.
+
+## Description
+
+Users should have control over their data. This control ensures that apps provide mechanisms for users to manage, delete, and modify their data, and change privacy settings as needed (e.g. to revoke consent). Additionally, apps should re-prompt for consent and update their transparency disclosures when they require more data than initially specified.

--- a/tools/populate_masvs_categories_md.py
+++ b/tools/populate_masvs_categories_md.py
@@ -31,7 +31,7 @@ def yaml_to_md(input_dir, input_file, for_website):
                 if group_id_in_file == group_id:
                     with open(os.path.join(input_dir, file), "a") as f:
                         if for_website == False:
-                            f.write('\n\n## Controls\n')
+                            f.write('\n## Controls\n\n')
                         else:
                             f.write('\n<style> table { width: 100%; } </style>\n\n')
                         f.write('| ID | Control |\n')


### PR DESCRIPTION
After collecting and processing all feedback from the [MASVS-PRIVACY Proposal](https://docs.google.com/document/d/1jq7V9cRureRFF_XT7d_Z9H_SLsaFs43cE50k6zMRu0Q/edit?usp=sharing) we're releasing the new MASVS-PRIVACY category.

> The main goal of MASVS-PRIVACY is to provide a **baseline for user privacy**. It is not intended to cover all aspects of user privacy, especially when other standards and regulations such as ENISA or the GDPR already do that. We focus on the app itself, looking at what can be tested using information that's publicly available or found within the app through methods like static or dynamic analysis.
> 
> While some associated tests can be automated, others necessitate manual intervention due to the nuanced nature of privacy. For example, if an app collects data that it didn't mention in the app store or its privacy policy, it takes careful manual checking to spot this.
