### PR TITLE
Update MAS Testing Profiles link and description

### DIFF
--- a/Document/03-Using_the_MASVS.md
+++ b/Document/03-Using_the_MASVS.md
@@ -25,7 +25,7 @@ Each of these control groups contains individual controls labeled **MASVS-XXXXX-
 
 ## MAS Testing Profiles
 
-The MAS project has traditionally provided three verification levels (L1, L2 and R), which were revisited during the MASVS refactoring in 2023, and have been reworked as ["MAS Testing Profiles"](https://docs.google.com/document/d/1paz7dxKXHzAC9MN7Mnln1JiZwBNyg7Gs364AJ6KudEs/edit?usp=sharing) and moved over to the OWASP MASTG. These profiles are now aligned with the [NIST OSCAL (Open Security Controls Assessment Language)](https://pages.nist.gov/OSCAL/) standard, which is a comprehensive catalog of security controls that can be used to secure information systems.
+The MAS project has traditionally provided three verification levels (L1, L2 and R), which were revisited during the MASVS refactoring in 2023, and have been reworked as ["MAS Testing Profiles"](https://mas.owasp.org/MASTG/0x03b-Testing-Profiles/) and moved over to the OWASP MASTG. These profiles are now aligned with the [NIST OSCAL (Open Security Controls Assessment Language)](https://pages.nist.gov/OSCAL/) standard, which is a comprehensive catalog of security controls that can be used to secure information systems.
 
 By aligning with OSCAL, the MASVS provides a more flexible and comprehensive approach to security testing. OSCAL provides a standard format for security control information, which allows for easier sharing and reuse of security controls across different systems and organizations. This allows for a more efficient use of resources and a more targeted approach to mobile app security testing.
 


### PR DESCRIPTION
pdated the MAS Testing Profiles section in `Document/03-Using_the_MASVS.md` to point to the official OWASP MASTG page instead of a Google Docs link, ensuring users are directed to the latest authoritative resource.